### PR TITLE
Add multiple mirrors

### DIFF
--- a/src/core/reducer/index.ts
+++ b/src/core/reducer/index.ts
@@ -44,7 +44,7 @@ export const defaultState: State = {
 export function reducer(state: State, action: Action): State {
     return {
         ...state,
-        mirrors: mirrorReducer(state.mirrors, action),
+        mirrors: mirrorReducer(state.mirrors, state.world, action),
         observer: observerReducer(state.observer, action),
         observableObjects: observableObjectReducer(state.observableObjects, state.world, action),
         simulationOptions: simulationOptionsReducer(state.simulationOptions, action)
@@ -53,7 +53,7 @@ export function reducer(state: State, action: Action): State {
 
 // Child Reducers
 
-export function mirrorReducer(mirrors: VerticalMirror[], action: Action): VerticalMirror[] {
+export function mirrorReducer(mirrors: VerticalMirror[], world: World, action: Action): VerticalMirror[] {
     if (!action.type.startsWith("VERTICAL-MIRROR")) {
         return mirrors;
     }
@@ -69,7 +69,6 @@ export function mirrorReducer(mirrors: VerticalMirror[], action: Action): Vertic
             return mirror;
         });
     }
-
     else if (action.type === "VERTICAL-MIRROR-CHANGE-LENGTH") {
         return mirrors.map(mirror => {
             if (mirror.id === action.mirrorId) {
@@ -80,6 +79,21 @@ export function mirrorReducer(mirrors: VerticalMirror[], action: Action): Vertic
             }
             return mirror;
         });
+    } else if (action.type === "VERTICAL-MIRROR-ADD") {
+        return [
+            ...mirrors,
+            {
+                id: crypto.randomUUID().toString(),
+                type: "vertical-mirror",
+                position: {
+                    x: getRandomInt(50, world.width - 50),
+                    y: getRandomInt(50, world.height - 50)
+                },
+                length: 140
+            }
+        ]
+    } else if (action.type === "VERTICAL-MIRROR-REMOVE") {
+        return mirrors.filter(mirror => mirror.id !== action.mirrorId);
     }
 
 

--- a/src/mirror-lab-sandbox/components/MirrorControls.tsx
+++ b/src/mirror-lab-sandbox/components/MirrorControls.tsx
@@ -9,6 +9,9 @@ import { State } from "@/core/reducer/types";
 import { useDispatch, useState } from "@/lib/StateContext";
 import PointEditor from "./editor/PointEditor";
 import LengthEditor from "./editor/LengthEditor";
+import IconButton from "@/component-library/components/IconButton";
+import { CirclePlus } from "lucide-react";
+import { SimulationLimits } from "@/core/limits";
 
 export default function MirrorControls() {
     const state: State = useState();
@@ -17,11 +20,28 @@ export default function MirrorControls() {
     return (
         <section className="optics-lab-control-section">
             <Header title="🪞 Mirrors">
+                <IconButton
+                    disabled={state.mirrors.length >= SimulationLimits.numberOfMirrors}
+                    onClick={() => {
+                        dispatch({
+                            type: "VERTICAL-MIRROR-ADD",
+                        })
+                    }}>
+                    <CirclePlus size={26} />
+                </IconButton>
+
             </Header>
 
             <div className="control-card-list">
                 {state.mirrors.map(mirror => (
                     <IconCard
+                        showRemove={true}
+                        onRemove={() => {
+                            dispatch({
+                                type: "VERTICAL-MIRROR-REMOVE",
+                                mirrorId: mirror.id
+                            })
+                        }}
                         key={`mirror-control-panel-${mirror.id}`}
                         icon={(
                             <MirrorIcon />
@@ -59,7 +79,8 @@ export default function MirrorControls() {
 function MirrorIcon() {
     return (
         <div className="optics-lab-control-mirror-icon">
-            <h3>A</h3>
+            {/* NOTE(NEW): Placeholder for mirror label in the future */}
+            <h3> </h3>
         </div>
     )
 }

--- a/src/mirror-lab/optics-components/LightPath.tsx
+++ b/src/mirror-lab/optics-components/LightPath.tsx
@@ -33,7 +33,7 @@ export default function LightPath() {
                     // Return the SVG path element
                     return (
                         <path
-                            key={`path-${pathIndex}-${path.reflectedObject}`}
+                            key={crypto.randomUUID()}
                             d={pathString}
                             stroke={`rgba(255,213,49,0.44)`}
                             strokeWidth={5}

--- a/src/mirror-lab/optics-components/Reflections.tsx
+++ b/src/mirror-lab/optics-components/Reflections.tsx
@@ -14,13 +14,13 @@ export default function Reflections({ virtualObjects }: ReflectionsProps) {
                     if (reflection.type === "observer") {
                         return (
                             <ObserverReflection
-                                key={`reflection-${reflection}`}
+                                key={crypto.randomUUID()}
                                 position={reflection.position} />
                         )
                     } else if (reflection.type === "object") {
                         return (
                             <ObservableReflection
-                                key={`reflection-object-${reflection.reflectedObject}`}
+                                key={crypto.randomUUID()}
                                 position={reflection.position}
                                 color={reflection.color!} />
                         )

--- a/src/mirror-lab/optics-components/VisiblePaths.tsx
+++ b/src/mirror-lab/optics-components/VisiblePaths.tsx
@@ -24,7 +24,7 @@ export default function VisiblePaths({ virtualObjects, observer }: VisiblePathsP
             {virtualObjects.map((virtualObj: VirtualObject) => (
                 virtualObj.type == "object" && (
                     <line
-                        key={`path-${virtualObj.reflectedObject}-${virtualObj.type}`}
+                        key={crypto.randomUUID()}
                         x1={observer.position.x}
                         y1={observer.position.y}
                         x2={virtualObj.position.x + 3}


### PR DESCRIPTION
This adds multiple mirrors.

There is also an unusual step here of negating the use of React's keys on reflections and rays. These should NOT be cached because they are re-calculated on every move and new draw. This is a bit of a hack and given more time I'd think about a more detailed solution